### PR TITLE
Properly preserve prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ npm install --save-dev babel-plugin-transform-decorators-stage-2-initial
 
 ### Known Gaps
 
-Class decorators will generally not work without also transforming the class declaration itself, e.g. with [`transform-es2015-classes`](https://www.npmjs.com/package/babel-plugin-transform-es2015-classes).
+This transform will generally not work without also transforming the class declaration itself, e.g. with [`transform-es2015-classes`](https://www.npmjs.com/package/babel-plugin-transform-es2015-classes).
 It *might* work when native `Reflect.construct` is used (e.g. node 6+) instead of a polyfill.

--- a/lib/babel-plugin-transform-decorators-stage-2-initial.js
+++ b/lib/babel-plugin-transform-decorators-stage-2-initial.js
@@ -164,9 +164,11 @@ function decorateClass(ctor, target, elements, classDecorators) {
 
     var klass = function CLASS_NAME() {
       classCallCheck(this, klass);
-      return Reflect.construct(finalCtor, arguments, ctor);
+      return Reflect.construct(finalCtor, arguments, this.constructor);
     };
+    Object.setPrototypeOf(klass, Object.getPrototypeOf(ctor));
     var proto = klass.prototype = ctor.prototype;
+    proto.constructor = klass;
 
     classDescriptor.members.forEach(function defineElement(element) {
       var propTarget = element.isStatic ? klass : proto;

--- a/test/method-decorators.test.js
+++ b/test/method-decorators.test.js
@@ -15,7 +15,8 @@ var TEST_CASES = fs.readdirSync(TEST_DIR);
 function toES6Code(source) {
   return babel.transform(source, {
     plugins: [
-      babelPluginTransformDecoratorsStage2Initial
+      babelPluginTransformDecoratorsStage2Initial,
+      'transform-es2015-classes'
     ]
   }).code;
 }


### PR DESCRIPTION
The previous wrapping decorator would actually break the prototype chain. Oops.
